### PR TITLE
Handle negative displacements in relative address calculations

### DIFF
--- a/GOffsets/GOffsets.cpp
+++ b/GOffsets/GOffsets.cpp
@@ -250,8 +250,9 @@ uint64_t findOffsetInProcessMemory(HANDLE hProcess, const std::vector<Byte>& pat
     foundOffset = adjustFoundOffsetForGroup(buffer, foundOffset, group);
     int32_t disp = *reinterpret_cast<const int32_t*>(&buffer[foundOffset + 3]);
     size_t nextInstr = foundOffset + 7;
-    size_t rawAddress = nextInstr + disp;
-    uint64_t rva = rawAddress;
+    int64_t rawAddress = static_cast<int64_t>(nextInstr) + disp;
+    size_t rawAddressPos = static_cast<size_t>(rawAddress);
+    uint64_t rva = rawAddressPos;
     return rva;
 }
 

--- a/GSpots.cpp
+++ b/GSpots.cpp
@@ -61,9 +61,10 @@ int main(int argc, char* argv[]) {
 
                 int32_t disp = *reinterpret_cast<const int32_t*>(&data[foundOffset + 3]);
                 size_t nextInstr = foundOffset + 7;
-                size_t rawAddress = nextInstr + disp;
+                int64_t rawAddress = static_cast<int64_t>(nextInstr) + disp;
+                size_t rawAddressPos = static_cast<size_t>(rawAddress);
                 uint32_t sectionDelta = getSectionDelta(data, foundOffset);
-                uint64_t computedAddress = rawAddress + sectionDelta;
+                uint64_t computedAddress = rawAddressPos + sectionDelta;
 
                 if (sig.name.find("GWorld") != std::string::npos && fileGWorld == 0)
                     fileGWorld = computedAddress;


### PR DESCRIPTION
## Summary
- Cast base address to signed 64-bit before adding displacements to avoid wraparound.
- Use `rawAddressPos` for subsequent calculations in offset scanners.

## Testing
- `g++ -std=c++17 GSpots.cpp GOffsets/GOffsets.cpp UEVersionScanner/UEVersionScanner.cpp EncryptionDetection/EncryptionDetection.cpp -o gspots` *(fails: windows.h: No such file or directory)*
- `g++ -std=c++17 /tmp/negative_disp_test.cpp -o /tmp/negative_disp_test && /tmp/negative_disp_test`

------
https://chatgpt.com/codex/tasks/task_e_68ad6687e9cc8330804e6f7a5df2386f